### PR TITLE
comment out cloudinary in insatalled apps

### DIFF
--- a/backend/django/settings/base.py
+++ b/backend/django/settings/base.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
     "cloudinary_storage",
     'django.contrib.staticfiles',
 
-    "cloudinary",
+    #"cloudinary",
     
     'corsheaders',
     'rest_framework',


### PR DESCRIPTION
Comment out the 'cloudinary' app in Django settings.